### PR TITLE
Aws gateway v4 testing

### DIFF
--- a/src/pact/client/awssign.pacttest.ts
+++ b/src/pact/client/awssign.pacttest.ts
@@ -17,79 +17,79 @@ jestpact.pactWith(
     describe('aws signed gateway test', () => {
       test('should be able to access /pets when authenticated', async () => {
         const apiPath = '/pets';
+        const expectedStatusCode = 200
+        const expectedResponseBody = [
+          {
+            id: 1,
+            type: 'dog',
+            price: 249.99
+          },
+          {
+            id: 2,
+            type: 'cat',
+            price: 124.99
+          },
+          {
+            id: 3,
+            type: 'fish',
+            price: 0.99
+          }
+        ]
         const interaction: InteractionObject = {
           state: 'Is authenticated',
           uponReceiving: 'a validated request to an api protected gateway',
           withRequest: {
             method: 'GET',
-            path: '/pets'
+            path: apiPath
           },
           willRespondWith: {
             headers: {
               'Content-Type': 'application/json'
             },
-            body: [
-              {
-                id: 1,
-                type: 'dog',
-                price: 249.99
-              },
-              {
-                id: 2,
-                type: 'cat',
-                price: 124.99
-              },
-              {
-                id: 3,
-                type: 'fish',
-                price: 0.99
-              }
-            ],
-            status: 200
+            body: expectedResponseBody,
+            status: expectedStatusCode
           }
         };
         await provider.addInteraction(interaction);
-        await client().get(apiPath).expect(200);
+        await client().get(apiPath).expect(expectedStatusCode);
       });
       test('should be able create /pets when authenticated', async () => {
         const apiPath = '/pets';
+        const requestBody = {
+          type: 'cat',
+          price: 123.11
+        }
+        const expectedStatusCode = 200
+        const expectedResponseBody = {
+          pet: requestBody,
+          message: 'success'
+        }
         const interaction: InteractionObject = {
           state: 'Is authenticated',
           uponReceiving:
             'a validated request to an api protected gateway to create a pet',
           withRequest: {
             method: 'POST',
-            path: '/pets',
-            body: {
-              type: 'cat',
-              price: 123.11
-            }
+            path: apiPath,
+            body: requestBody
           },
           willRespondWith: {
             headers: {
               'Content-Type': 'application/json'
             },
-            body: {
-              pet: {
-                type: 'cat',
-                price: 123.11
-              },
-              message: 'success'
-            },
-            status: 200
+            body: expectedResponseBody,
+            status: expectedStatusCode
           }
         };
         await provider.addInteraction(interaction);
         await client()
           .post(apiPath)
-          .send({
-            type: 'cat',
-            price: 123.11
-          })
-          .expect(200);
+          .send(requestBody)
+          .expect(expectedStatusCode);
       });
       test('should not be able to access /pets when not authenticated', async () => {
         const apiPath = '/pets';
+        const expectedStatusCode = 403
         const interaction: InteractionObject = {
           state: 'Is not authenticated',
           uponReceiving: 'a non-validated request to an api protected gateway',
@@ -104,13 +104,13 @@ jestpact.pactWith(
             body: {
               message: 'Missing Authentication Token'
             },
-            status: 403
+            status: expectedStatusCode
           }
         };
 
         await provider.addInteraction(interaction);
 
-        await client().get(apiPath).expect(403);
+        await client().get(apiPath).expect(expectedStatusCode);
       });
     });
   }

--- a/src/pact/client/awssign.pacttest.ts
+++ b/src/pact/client/awssign.pacttest.ts
@@ -15,30 +15,81 @@ jestpact.pactWith(
     };
 
     describe('aws signed gateway test', () => {
-      test('should be able to access /helloworld when authenticated', async () => {
-        const apiPath = '/helloworld';
+      test('should be able to access /pets when authenticated', async () => {
+        const apiPath = '/pets';
         const interaction: InteractionObject = {
           state: 'Is authenticated',
           uponReceiving: 'a validated request to an api protected gateway',
           withRequest: {
             method: 'GET',
-            path: '/helloworld'
+            path: '/pets'
           },
           willRespondWith: {
             headers: {
               'Content-Type': 'application/json'
             },
-            body: {
-              message: 'Hello from Lambda!'
-            },
+            body: [
+              {
+                id: 1,
+                type: 'dog',
+                price: 249.99
+              },
+              {
+                id: 2,
+                type: 'cat',
+                price: 124.99
+              },
+              {
+                id: 3,
+                type: 'fish',
+                price: 0.99
+              }
+            ],
             status: 200
           }
         };
         await provider.addInteraction(interaction);
         await client().get(apiPath).expect(200);
       });
-      test('should not be able to access /helloworld when not authenticated', async () => {
-        const apiPath = '/helloworld';
+      test('should be able create /pets when authenticated', async () => {
+        const apiPath = '/pets';
+        const interaction: InteractionObject = {
+          state: 'Is authenticated',
+          uponReceiving:
+            'a validated request to an api protected gateway to create a pet',
+          withRequest: {
+            method: 'POST',
+            path: '/pets',
+            body: {
+              type: 'cat',
+              price: 123.11
+            }
+          },
+          willRespondWith: {
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: {
+              pet: {
+                type: 'cat',
+                price: 123.11
+              },
+              message: 'success'
+            },
+            status: 200
+          }
+        };
+        await provider.addInteraction(interaction);
+        await client()
+          .post(apiPath)
+          .send({
+            type: 'cat',
+            price: 123.11
+          })
+          .expect(200);
+      });
+      test('should not be able to access /pets when not authenticated', async () => {
+        const apiPath = '/pets';
         const interaction: InteractionObject = {
           state: 'Is not authenticated',
           uponReceiving: 'a non-validated request to an api protected gateway',


### PR DESCRIPTION
An example to showcase verifying pacts against an AWS Lambda function, with an API gateway, that requires [AWSv4 signed request headers](https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html)

See initial feature request here:- https://github.com/pact-foundation/pact-js/issues/304


API Gateway was created via a Swagger/OpenAPI definition


You can re-create and run this example by following the instructions on here

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-from-example.html

You can convert the Swagger 2.0 example shown in the AWS API Gateway UI to OpenAPI 3.0.1 by pasting the contents into https://editor.swagger.io/  and selecting `edit` -> `Convert to OpenAPI 3.0`

Follow the first step in this AWS workshop to enable `AWS IAM` authentication on the endpoints, which will give you an auth protected AWS gateway, in which to test against 

https://catalog.us-east-1.prod.workshops.aws/workshops/dc413216-deab-4371-9e4a-879a4f14233d/en-US/4-improve-existing-architecture/task1-apigwauth#1.1-enable-api-gateway-authorization-with-aws-iam


